### PR TITLE
Fix panic in Glob on empty subject string.

### DIFF
--- a/glob.go
+++ b/glob.go
@@ -40,9 +40,7 @@ func Glob(pattern, subj string) bool {
 				return false
 			}
 		case end:
-			if len(subj) > 0 {
-				return trailingGlob || strings.HasSuffix(subj, part)
-			}
+			return trailingGlob || strings.HasSuffix(subj, part)
 		default:
 			if !strings.Contains(subj, part) {
 				return false
@@ -54,6 +52,7 @@ func Glob(pattern, subj string) bool {
 		subj = subj[idx:]
 	}
 
-	// All parts of the pattern matched
-	return true
+	// We should never get here because "case end:" above should always trigger at the end of
+	// iterating over parts. If we do, it's a bug in this library that should be reported and fixed.
+	panic("unreachable")
 }

--- a/glob_test.go
+++ b/glob_test.go
@@ -1,6 +1,9 @@
 package glob
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func testGlobMatch(t *testing.T, pattern, subj string) {
 	if !Glob(pattern, subj) {
@@ -17,6 +20,19 @@ func testGlobNoMatch(t *testing.T, pattern, subj string) {
 func TestEmptyPattern(t *testing.T) {
 	testGlobMatch(t, "", "")
 	testGlobNoMatch(t, "", "test")
+}
+
+func TestEmptySubject(t *testing.T) {
+	testGlobMatch(t, "", "")
+	testGlobNoMatch(t, "test", "")
+	testGlobMatch(t, "*", "")
+	testGlobMatch(t, "**", "")
+	testGlobMatch(t, "***", "")
+	testGlobMatch(t, "******************************", "")
+	testGlobMatch(t, strings.Repeat("*", 1000000), "")
+	testGlobNoMatch(t, strings.Repeat("*", 1000000)+"x", "")
+	testGlobNoMatch(t, "x"+strings.Repeat("*", 1000000), "")
+	testGlobNoMatch(t, "x"+strings.Repeat("*", 1000000)+"x", "")
 }
 
 func TestPatternWithoutGlobs(t *testing.T) {


### PR DESCRIPTION
Fixes #1.

Add tests.

Add test (in form of example) and benchmark for internal `globSequence` utility.