### PR TITLE
Add an ability to prepare (compile) pattern before glob

### DIFF
--- a/glob.go
+++ b/glob.go
@@ -5,52 +5,59 @@ import "strings"
 // The character which is treated like a glob
 const GLOB = "*"
 
-// Glob will test a string pattern, potentially containing globs, against a
-// subject string. The result is a simple true/false, determining whether or
-// not the glob pattern matched the subject text.
-func Glob(pattern, subj string) bool {
+// Compile will prepare a string pattern and return a function for further matching.
+func Compile(pattern string) func(subj string) bool {
 	// Empty pattern can only match empty subject
 	if pattern == "" {
-		return subj == pattern
+		return func(subj string) bool { return subj == "" }
 	}
 
 	// If the pattern _is_ a glob, it matches everything
 	if pattern == GLOB {
-		return true
+		return func(subj string) bool { return true }
 	}
 
 	parts := strings.Split(pattern, GLOB)
 
 	if len(parts) == 1 {
 		// No globs in pattern, so test for equality
-		return subj == pattern
+		return func(subj string) bool { return subj == pattern }
 	}
 
 	leadingGlob := strings.HasPrefix(pattern, GLOB)
 	trailingGlob := strings.HasSuffix(pattern, GLOB)
 	end := len(parts) - 1
 
-	// Go over the leading parts and ensure they match.
-	for i := 0; i < end; i++ {
-		idx := strings.Index(subj, parts[i])
+	return func(subj string) bool {
+		// Go over the leading parts and ensure they match.
+		for i := 0; i < end; i++ {
+			idx := strings.Index(subj, parts[i])
 
-		switch i {
-		case 0:
-			// Check the first section. Requires special handling.
-			if !leadingGlob && idx != 0 {
-				return false
+			switch i {
+			case 0:
+				// Check the first section. Requires special handling.
+				if !leadingGlob && idx != 0 {
+					return false
+				}
+			default:
+				// Check that the middle parts match.
+				if idx < 0 {
+					return false
+				}
 			}
-		default:
-			// Check that the middle parts match.
-			if idx < 0 {
-				return false
-			}
+
+			// Trim evaluated text from subj as we loop over the pattern.
+			subj = subj[idx+len(parts[i]):]
 		}
 
-		// Trim evaluated text from subj as we loop over the pattern.
-		subj = subj[idx+len(parts[i]):]
+		// Reached the last section. Requires special handling.
+		return trailingGlob || strings.HasSuffix(subj, parts[end])
 	}
+}
 
-	// Reached the last section. Requires special handling.
-	return trailingGlob || strings.HasSuffix(subj, parts[end])
+// Glob will test a string pattern, potentially containing globs, against a
+// subject string. The result is a simple true/false, determining whether or
+// not the glob pattern matched the subject text.
+func Glob(pattern, subj string) bool {
+	return Compile(pattern)(subj)
 }

--- a/glob_test.go
+++ b/glob_test.go
@@ -103,3 +103,13 @@ func BenchmarkGlob(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkCompiledGlob(b *testing.B) {
+	compiledGlob := Compile("*quick*fox*dog")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !compiledGlob("The quick brown fox jumped over the lazy dog") {
+			b.Fatalf("should match")
+		}
+	}
+}


### PR DESCRIPTION
Thanks for this simple library. I need to test matching a lot of strings with the same pattern, so for performance reasons, it would be better to prepare the last one before.
Microbench:
```
$ go version
go version go1.15.1 darwin/amd64

$ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/ryanuber/go-glob
BenchmarkGlob-8                  5427961               219 ns/op
BenchmarkCompiledGlob-8         31287264                37.4 ns/op
PASS
ok      github.com/ryanuber/go-glob     2.814s
```