### PR TITLE
AddingPowerSupport_For_golang-github-ryanuber-go-glob

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+arch: 
+  - amd64
+  - ppc64le
+  
 language: go
 go:
   - tip


### PR DESCRIPTION
Adding Power Support.

Adding power support ppc64le.

@ryanuber, This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

If all the checks are successful, Can you please approve this PR?